### PR TITLE
Make two methods public in RestSinkConnectorConfig

### DIFF
--- a/src/main/java/com/tm/kafka/connect/rest/RestSinkConnectorConfig.java
+++ b/src/main/java/com/tm/kafka/connect/rest/RestSinkConnectorConfig.java
@@ -160,7 +160,7 @@ public class RestSinkConnectorConfig extends AbstractConfig implements RequestTr
     this(conf(), parsedConfig);
   }
 
-  static ConfigDef conf() {
+  public static ConfigDef conf() {
     String group = "REST";
     int orderInGroup = 0;
     return new ConfigDef()
@@ -400,7 +400,7 @@ public class RestSinkConnectorConfig extends AbstractConfig implements RequestTr
     return this.getBoolean(SINK_PAYLOAD_CONVERTER_SCHEMA_CONFIG);
   }
 
-  SinkRecordToPayloadConverter getSinkRecordToPayloadConverter() {
+  public SinkRecordToPayloadConverter getSinkRecordToPayloadConverter() {
     return sinkRecordToPayloadConverter;
   }
 


### PR DESCRIPTION
I'd like to extend the sink task for a very specific implementation, but not being able to access these methods outside the package is giving me trouble. I see no reason for these 2 methods to be package private, especially since other similar methods are not.