### PR TITLE
Adding changes in terms to manage the format of date in the URL request

### DIFF
--- a/src/main/java/com/tm/kafka/connect/rest/RestSinkConnectorConfig.java
+++ b/src/main/java/com/tm/kafka/connect/rest/RestSinkConnectorConfig.java
@@ -133,6 +133,11 @@ public class RestSinkConnectorConfig extends AbstractConfig implements RequestTr
   private static final String SINK_VELOCITY_TEMPLATE_DEFAULT = "rest.vm";
   private static final String SINK_VELOCITY_TEMPLATE_DISPLAY = "Velocity template";
 
+  static final String SINK_DATE_FORMAT_CONFIG = "rest.http.date.format";
+  private static final String SINK_DATE_FORMAT_DISPLAY = "Date format for interpolation";
+  private static final String SINK_DATE_FORMAT_DOC = "Date format for interpolation. The default is MM-dd-yyyy HH:mm:ss.SSS";
+  private static final String SINK_DATE_FORMAT_DEFAULT = "MM-dd-yyyy HH:mm:ss.SSS";
+
   private static final long SINK_RETRY_BACKOFF_DEFAULT = 5000L;
 
   private final SinkRecordToPayloadConverter sinkRecordToPayloadConverter;
@@ -359,13 +364,23 @@ public class RestSinkConnectorConfig extends AbstractConfig implements RequestTr
         ++orderInGroup,
         ConfigDef.Width.NONE,
         SINK_VELOCITY_TEMPLATE_DISPLAY)
+
+      .define(SINK_DATE_FORMAT_CONFIG,
+        Type.STRING,
+        SINK_DATE_FORMAT_DEFAULT,
+        Importance.LOW,
+        SINK_DATE_FORMAT_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.NONE,
+        SINK_DATE_FORMAT_DISPLAY)
       ;
   }
 
   public Interpolator getInterpolator() {
     return new DefaultInterpolator(Arrays.asList(
       new EnvironmentVariableInterpolationSource(),
-      new UtilInterpolationSource(),
+      new UtilInterpolationSource(this.getString(SINK_DATE_FORMAT_CONFIG)),
       new PayloadInterpolationSource(),
       new PropertyInterpolationSource()
     ));

--- a/src/main/java/com/tm/kafka/connect/rest/RestSourceConnectorConfig.java
+++ b/src/main/java/com/tm/kafka/connect/rest/RestSourceConnectorConfig.java
@@ -116,6 +116,11 @@ public class RestSourceConnectorConfig extends AbstractConfig implements Request
   private static final String SOURCE_REQUEST_EXECUTOR_DOC = "HTTP request executor. Default is OkHttpRequestExecutor";
   private static final String SOURCE_REQUEST_EXECUTOR_DEFAULT = "com.tm.kafka.connect.rest.http.executor.OkHttpRequestExecutor";
 
+  static final String SOURCE_DATE_FORMAT_CONFIG = "rest.http.date.format";
+  private static final String SOURCE_DATE_FORMAT_DISPLAY = "Date format for interpolation";
+  private static final String SOURCE_DATE_FORMAT_DOC = "Date format for interpolation. The default is MM-dd-yyyy HH:mm:ss.SSS";
+  private static final String SOURCE_DATE_FORMAT_DEFAULT = "MM-dd-yyyy HH:mm:ss.SSS";
+
   private final TopicSelector topicSelector;
   private final PayloadToSourceRecordConverter payloadToSourceRecordConverter;
   private final Map<String, String> requestProperties;
@@ -324,13 +329,23 @@ public class RestSourceConnectorConfig extends AbstractConfig implements Request
         ++orderInGroup,
         ConfigDef.Width.NONE,
         SOURCE_REQUEST_EXECUTOR_DISPLAY)
+
+      .define(SOURCE_DATE_FORMAT_CONFIG,
+        Type.STRING,
+        SOURCE_DATE_FORMAT_DEFAULT,
+        Importance.LOW,
+        SOURCE_DATE_FORMAT_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.NONE,
+        SOURCE_DATE_FORMAT_DISPLAY)
       ;
   }
 
   public Interpolator getInterpolator() {
     return new DefaultInterpolator(Arrays.asList(
       new EnvironmentVariableInterpolationSource(),
-      new UtilInterpolationSource(),
+      new UtilInterpolationSource(this.getString(SOURCE_DATE_FORMAT_CONFIG)),
       new PayloadInterpolationSource(),
       new PropertyInterpolationSource()
     ));

--- a/src/main/java/com/tm/kafka/connect/rest/interpolator/source/UtilInterpolationSource.java
+++ b/src/main/java/com/tm/kafka/connect/rest/interpolator/source/UtilInterpolationSource.java
@@ -11,6 +11,11 @@ import java.util.Date;
 public class UtilInterpolationSource implements InterpolationSource {
 
   private static Logger log = LoggerFactory.getLogger(UtilInterpolationSource.class);
+  private String dateFormat;
+
+  public UtilInterpolationSource(String dateFormat) {
+    this.dateFormat = dateFormat;
+  }
 
   enum UtilType {
     timestamp, date
@@ -28,7 +33,7 @@ public class UtilInterpolationSource implements InterpolationSource {
 
     switch (type) {
       case timestamp: return Util.getCurrentTimestamp();
-      case date:      return Util.getDate();
+      case date:      return Util.getDate(this.dateFormat);
       default:        return "";
     }
 
@@ -45,10 +50,11 @@ public class UtilInterpolationSource implements InterpolationSource {
 
   public static class Util {
 
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss.SSS");
+    //private static final DateFormat DATE_FORMAT = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss.SSS");
 
-    static String getDate() {
-      return DATE_FORMAT.format(new Date());
+    static String getDate(String dateFormat) {
+      return new SimpleDateFormat(dateFormat).format(new Date());
+      //return DATE_FORMAT.format(new Date());
     }
 
     static String getCurrentTimestamp() {


### PR DESCRIPTION
I have added a new key in order to allow the possibility to change the date format using the interpolation. This is necessary for me because I can call API using the current timestamp of the request using a custom date format. I will leave also the default date format in terms do not have problems to convert the current date