### PR TITLE
Bump parent version in sub-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Building and running Spring example in docker
     cd examples/spring/gs-rest-service && \
     mvn clean install && \
     cd .. && \
-    cp ../../kafka-connect-rest-plugin/target/kafka-connect-rest-plugin-1.0-SNAPSHOT-shaded.jar jars/ && \
-    cp ../../kafka-connect-transform-from-json/kafka-connect-transform-from-json-plugin/target/kafka-connect-transform-from-json-plugin-1.0-SNAPSHOT-shaded.jar jars/ && \
-    cp ../../kafka-connect-transform-add-headers/target/kafka-connect-transform-add-headers-1.0-SNAPSHOT-shaded.jar jars/ && \
-    cp ../../kafka-connect-transform-velocity-eval/target/kafka-connect-transform-velocity-eval-1.0-SNAPSHOT-shaded.jar jars/ && \
+    cp ../../kafka-connect-rest-plugin/target/kafka-connect-rest-plugin-1.0-shaded.jar jars/ && \
+    cp ../../kafka-connect-transform-from-json/kafka-connect-transform-from-json-plugin/target/kafka-connect-transform-from-json-plugin-1.0-shaded.jar jars/ && \
+    cp ../../kafka-connect-transform-add-headers/target/kafka-connect-transform-add-headers-1.0-shaded.jar jars/ && \
+    cp ../../kafka-connect-transform-velocity-eval/target/kafka-connect-transform-velocity-eval-1.0-shaded.jar jars/ && \
     docker-compose up -d
 
     docker exec -it spring_connect_1 bash -c \

--- a/kafka-connect-rest-plugin/pom.xml
+++ b/kafka-connect-rest-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>kafka-connect-rest</artifactId>
     <groupId>com.tm.kafka</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
   </parent>
 
   <artifactId>kafka-connect-rest-plugin</artifactId>

--- a/kafka-connect-transform-add-headers/pom.xml
+++ b/kafka-connect-transform-add-headers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-connect-rest</artifactId>
     <groupId>com.tm.kafka</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-connect-transform-from-json/kafka-connect-transform-from-json-avro/pom.xml
+++ b/kafka-connect-transform-from-json/kafka-connect-transform-from-json-avro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-connect-transform-from-json</artifactId>
     <groupId>com.tm.kafka</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-connect-transform-from-json/kafka-connect-transform-from-json-plugin/pom.xml
+++ b/kafka-connect-transform-from-json/kafka-connect-transform-from-json-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-connect-transform-from-json</artifactId>
     <groupId>com.tm.kafka</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-connect-transform-from-json/pom.xml
+++ b/kafka-connect-transform-from-json/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.tm.kafka</groupId>
     <artifactId>kafka-connect-rest</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/kafka-connect-transform-velocity-eval/pom.xml
+++ b/kafka-connect-transform-velocity-eval/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-connect-rest</artifactId>
     <groupId>com.tm.kafka</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
The version bump to 1.0 seems to have broken the build because the sub-modules still referenced version 1.0-SNAPSHOT, and unless it happened to be hanging about on your machine, that version couldn't be found.