### PR TITLE
Make the project build under Java 11

### DIFF
--- a/examples/spring/gs-rest-service/pom.xml
+++ b/examples/spring/gs-rest-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.1.4.RELEASE</version>
     </parent>
 
     <dependencies>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.20</version>
+            <version>1.18.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/kafka-connect-rest-plugin/pom.xml
+++ b/kafka-connect-rest-plugin/pom.xml
@@ -84,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <jackson.version>2.9.8</jackson.version>
     <confluent.version>5.2.1</confluent.version>
     <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-    <powermock.version>1.7.4</powermock.version>
+    <powermock.version>2.0.2</powermock.version>
     <metrics.version>4.0.0</metrics.version>
     <avro.version>1.8.2</avro.version>
   </properties>
@@ -128,7 +128,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.10.19</version>
+        <version>2.27.0</version>
         <scope>test</scope>
       </dependency>
 
@@ -159,7 +159,7 @@
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito</artifactId>
+        <artifactId>powermock-api-mockito2</artifactId>
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
@@ -247,7 +247,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.3</version>
         <executions>
           <execution>
             <id>jacoco-initialize</id>


### PR DESCRIPTION
This is just upgrades to some of the build tooling so that the build runs under Java 11.  The build is still set to generate Java 1.8 compatible bytecode.