### PR TITLE
Add Request Payload Templating Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Kafka Connect REST connector
 
 Building and running Spring example in docker
 ---
+Build the project and copy the jars to the example
 
     mvn clean install && \
     cd examples/spring/gs-rest-service && \
@@ -11,13 +12,20 @@ Building and running Spring example in docker
     cp ../../kafka-connect-rest-plugin/target/kafka-connect-rest-plugin-*-shaded.jar jars/ && \
     cp ../../kafka-connect-transform-from-json/kafka-connect-transform-from-json-plugin/target/kafka-connect-transform-from-json-plugin-*-shaded.jar jars/ && \
     cp ../../kafka-connect-transform-add-headers/target/kafka-connect-transform-add-headers-*-shaded.jar jars/ && \
-    cp ../../kafka-connect-transform-velocity-eval/target/kafka-connect-transform-velocity-eval-*-shaded.jar jars/ && \
+    cp ../../kafka-connect-transform-velocity-eval/target/kafka-connect-transform-velocity-eval-*-shaded.jar jars/
+
+Bring up the docker containers
+
     docker-compose up -d
+
+Create the destination topic
 
     docker exec -it spring_connect_1 bash -c \
      "kafka-topics --zookeeper zookeeper \
        --topic restSourceDestinationTopic --create \
        --replication-factor 1 --partitions 1"
+
+Configure the sink and source connectors
 
     curl -X POST \
        -H 'Host: connect.example.com' \
@@ -31,15 +39,23 @@ Building and running Spring example in docker
        -H 'Content-Type: application/json' \
       http://localhost:8083/connectors -d @config/source.json
 
+View the contents of the destination topic
+
     docker exec -it spring_connect_1 bash -c \
      "kafka-avro-console-consumer --bootstrap-server kafka:9092 \
       --topic restSourceDestinationTopic --from-beginning \
       --property schema.registry.url=http://schema_registry:8081/"
 
+View the webserver logs
+
     docker logs -f spring_webservice_1
+
+Shutdown the docker containers
 
     docker-compose down
     cd ../..
+
+#### If you don't want to use Avro
 
 Change CONNECT_VALUE_CONVERTER in the docker-compose.yml
 to org.apache.kafka.connect.storage.StringConverter if you don't want to use Avro.

--- a/examples/spring/config/regex-template-source.json
+++ b/examples/spring/config/regex-template-source.json
@@ -1,0 +1,24 @@
+{
+  "name": "RegexTemplatedRestSourceConnectorSpring",
+  "config": {
+    "producer.compression.type": "snappy",
+    "connector.class": "com.tm.kafka.connect.rest.RestSourceConnector",
+    "tasks.max": "1",
+    "rest.source.poll.interval.ms": "10000",
+    "rest.source.method": "GET",
+    "rest.source.url": "http://webservice:8080/sum-plain",
+    "rest.source.destination.topics": "restSourceDestinationTopic",
+
+    "rest.source.data.generator": "com.tm.kafka.connect.rest.http.payload.templated.TemplatedPayloadGenerator",
+    "rest.source.param.names": "val1, val2",
+    "rest.source.param.val1.template": "${val2}",
+    "rest.source.param.val2.template": "${res}",
+    "rest.source.header.template": "Content-Type:text/plain, Accept:text/plain",
+
+    "rest.source.payload.value.provider": "com.tm.kafka.connect.rest.http.payload.templated.RegexResponseValueProvider",
+    "rest.source.response.var.names": "val1, val2, res",
+    "rest.source.response.var.val1.regex": "(\\d+)\\s+\\+\\s+\\d+\\s+=\\s+\\d+",
+    "rest.source.response.var.val2.regex": "\\d+\\s+\\+\\s+(\\d+)\\s+=\\s+\\d+",
+    "rest.source.response.var.res.regex": "\\d+\\s+\\+\\s+\\d+\\s+=\\s+(\\d+)"
+  }
+}

--- a/examples/spring/config/xpath-template-source.json
+++ b/examples/spring/config/xpath-template-source.json
@@ -1,12 +1,12 @@
 {
-  "name": "RegexTemplatedRestSourceConnectorSpring",
+  "name": "XPathTemplatedRestSourceConnectorSpring",
   "config": {
     "producer.compression.type": "snappy",
     "connector.class": "com.tm.kafka.connect.rest.RestSourceConnector",
     "tasks.max": "1",
     "rest.source.poll.interval.ms": "10000",
     "rest.source.method": "GET",
-    "rest.source.url": "http://webservice:8080/sum-plain",
+    "rest.source.url": "http://webservice:8080/sum-xml",
     "rest.source.destination.topics": "restSourceDestinationTopic",
 
     "rest.source.data.generator": "com.tm.kafka.connect.rest.http.payload.templated.TemplatedPayloadGenerator",
@@ -15,10 +15,10 @@
     "rest.source.param.val2.template": "$!{res}",
     "rest.source.header.template": "Content-Type:text/plain, Accept:text/plain",
 
-    "rest.source.payload.value.provider": "com.tm.kafka.connect.rest.http.payload.templated.RegexResponseValueProvider",
+    "rest.source.payload.value.provider": "com.tm.kafka.connect.rest.http.payload.templated.XPathResponseValueProvider",
     "rest.source.response.var.names": "val1, val2, res",
-    "rest.source.response.var.val1.regex": "(\\d+)\\s+\\+\\s+\\d+\\s+=\\s+\\d+",
-    "rest.source.response.var.val2.regex": "\\d+\\s+\\+\\s+(\\d+)\\s+=\\s+\\d+",
-    "rest.source.response.var.res.regex": "\\d+\\s+\\+\\s+\\d+\\s+=\\s+(\\d+)"
+    "rest.source.response.var.val1.xpath": "/calc/expr/val[1]",
+    "rest.source.response.var.val2.xpath": "/calc/expr/val[2]",
+    "rest.source.response.var.res.xpath": "/calc/result"
   }
 }

--- a/examples/spring/gs-rest-service/src/main/java/hello/Calculation.java
+++ b/examples/spring/gs-rest-service/src/main/java/hello/Calculation.java
@@ -1,0 +1,45 @@
+package hello;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@XmlRootElement(name = "calc")
+@XmlAccessorType(XmlAccessType.FIELD)
+class Calculation {
+  @XmlElement
+  private Expression expr;
+  @XmlElement
+  private Double result;
+
+  public Calculation(Expression.Operation operation, List<Double> values, Double result) {
+    this.expr = new Expression(operation, values);
+    this.result = result;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @XmlAccessorType(XmlAccessType.FIELD)
+  public static class Expression {
+    @XmlElement
+    private Operation operation;
+    @XmlElement(name = "val")
+    private List<Double> values;
+
+    public enum Operation {
+      SUM;
+    }
+  }
+}

--- a/examples/spring/gs-rest-service/src/main/java/hello/GreetingController.java
+++ b/examples/spring/gs-rest-service/src/main/java/hello/GreetingController.java
@@ -45,7 +45,13 @@ public class GreetingController {
       return greetOut;
     }
 
-    @PostMapping(value = "/count")
+  @RequestMapping(value = "/sum-plain", produces = "text/plain")
+  public String sum(@RequestParam(value = "val1", defaultValue = "1") long val1,
+                    @RequestParam(value = "val2", defaultValue = "1") long val2) {
+    return String.format("%d + %d = %d", val1, val2, (val1 + val2));
+  }
+
+  @PostMapping(value = "/count")
     public void count(@RequestBody Object request, @RequestHeader HttpHeaders headers) {
         log.info("Request /count: '{}', {}", request, headers);
     }

--- a/examples/spring/gs-rest-service/src/main/java/hello/GreetingController.java
+++ b/examples/spring/gs-rest-service/src/main/java/hello/GreetingController.java
@@ -1,10 +1,15 @@
 package hello;
 
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static hello.Calculation.Expression.Operation.*;
+
 
 @RestController
 @Slf4j
@@ -46,9 +51,15 @@ public class GreetingController {
     }
 
   @RequestMapping(value = "/sum-plain", produces = "text/plain")
-  public String sum(@RequestParam(value = "val1", defaultValue = "1") long val1,
-                    @RequestParam(value = "val2", defaultValue = "1") long val2) {
-    return String.format("%d + %d = %d", val1, val2, (val1 + val2));
+  public String sumPlain(@RequestParam(value = "val1", defaultValue = "1") double val1,
+                    @RequestParam(value = "val2", defaultValue = "1") double val2) {
+    return String.format("%f + %f = %f", val1, val2, (val1 + val2));
+  }
+
+  @RequestMapping(value = "/sum-xml", produces = "text/xml")
+  public Calculation sumXml(@RequestParam(value = "val1", defaultValue = "1") double val1,
+                    @RequestParam(value = "val2", defaultValue = "1") double val2) {
+    return new Calculation(SUM, Arrays.asList(val1, val2), (val1 + val2));
   }
 
   @PostMapping(value = "/count")

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/RestSourceConnectorConfig.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/RestSourceConnectorConfig.java
@@ -1,10 +1,7 @@
 package com.tm.kafka.connect.rest;
 
 
-import com.tm.kafka.connect.rest.config.InstanceOfValidator;
-import com.tm.kafka.connect.rest.config.MethodRecommender;
-import com.tm.kafka.connect.rest.config.MethodValidator;
-import com.tm.kafka.connect.rest.config.ServiceProviderInterfaceRecommender;
+import com.tm.kafka.connect.rest.config.*;
 import com.tm.kafka.connect.rest.http.executor.RequestExecutor;
 import com.tm.kafka.connect.rest.http.handler.DefaultResponseHandler;
 import com.tm.kafka.connect.rest.http.handler.ResponseHandler;

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/RestSourceTask.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/RestSourceTask.java
@@ -88,7 +88,7 @@ public class RestSourceTask extends SourceTask {
         }
 
         Map<String, String> sourcePartition = Collections.singletonMap("URL", url);
-        Map<String, Long> sourceOffset = Collections.singletonMap("timestamp", currentTimeMillis());
+        Map<String, Object> sourceOffset = payloadGenerator.getOffsets();
         for (String responseRecord : responseHandler.handle(response, ctx)) {
           SourceRecord sourceRecord = new SourceRecord(sourcePartition, sourceOffset,
             topicSelector.getTopic(responseRecord), Schema.STRING_SCHEMA, responseRecord);

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/RestSourceTask.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/RestSourceTask.java
@@ -15,10 +15,7 @@ import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.tm.kafka.connect.rest.metrics.Metrics.ERROR_METRIC;
 import static com.tm.kafka.connect.rest.metrics.Metrics.increaseCounter;
@@ -38,7 +35,8 @@ public class RestSourceTask extends SourceTask {
   private PayloadGenerator payloadGenerator;
   private ResponseHandler responseHandler;
   private TopicSelector topicSelector;
-  private String url;
+  private Map<String, String> sourcePartition;
+  private ExecutionContext ctx;
 
   @Override
   public void start(Map<String, String> properties) {
@@ -50,14 +48,22 @@ public class RestSourceTask extends SourceTask {
     }
 
     taskName = properties.getOrDefault("name", "unknown");
+    ctx = ExecutionContext.create(taskName);
 
     pollInterval = connectorConfig.getPollInterval();
-    url = connectorConfig.getUrl();
+    String url = connectorConfig.getUrl();
     requestFactory = new Request.RequestFactory(url, connectorConfig.getMethod());
     payloadGenerator = connectorConfig.getPayloadGenerator();
     responseHandler = connectorConfig.getResponseHandler();
     executor = connectorConfig.getRequestExecutor();
     topicSelector = connectorConfig.getTopicSelector();
+
+    sourcePartition = Collections.singletonMap("URL", url);
+    Map<String, Object> offsets = context.offsetStorageReader().offset(sourcePartition);
+    if(offsets != null) {
+      log.info("Loaded Offsets: " + Arrays.toString(offsets.entrySet().toArray()));
+      payloadGenerator.setOffsets(offsets);
+    }
   }
 
   @Override
@@ -67,7 +73,6 @@ public class RestSourceTask extends SourceTask {
       Thread.sleep(millis);
     }
 
-    ExecutionContext ctx = ExecutionContext.create(taskName);
     ArrayList<SourceRecord> records = new ArrayList<>();
     boolean makeAnotherRequest = true;
 
@@ -87,18 +92,16 @@ public class RestSourceTask extends SourceTask {
           log.trace("Response: {}, Request: {}", response, request);
         }
 
-        Map<String, String> sourcePartition = Collections.singletonMap("URL", url);
-        Map<String, Object> sourceOffset = payloadGenerator.getOffsets();
+        makeAnotherRequest = payloadGenerator.update(request, response);
+
         for (String responseRecord : responseHandler.handle(response, ctx)) {
-          SourceRecord sourceRecord = new SourceRecord(sourcePartition, sourceOffset,
+          SourceRecord sourceRecord = new SourceRecord(sourcePartition, payloadGenerator.getOffsets(),
             topicSelector.getTopic(responseRecord), Schema.STRING_SCHEMA, responseRecord);
           for (Map.Entry<String, List<String>> header : response.getHeaders().entrySet()) {
             sourceRecord.headers().add(header.getKey(), header.getValue(), SchemaBuilder.array(Schema.STRING_SCHEMA).build());
           }
           records.add(sourceRecord);
         }
-
-        makeAnotherRequest = payloadGenerator.update(request, response);
       }
     } catch (Exception e) {
       log.error("HTTP call execution failed " + e.getMessage(), e);
@@ -111,7 +114,7 @@ public class RestSourceTask extends SourceTask {
   }
 
   @Override
-  public void stop() {
+  public synchronized void stop() {
     log.debug("Stopping source task");
   }
 

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/ConstantPayloadGenerator.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/ConstantPayloadGenerator.java
@@ -5,7 +5,10 @@ import com.tm.kafka.connect.rest.http.Request;
 import com.tm.kafka.connect.rest.http.Response;
 import org.apache.kafka.common.Configurable;
 
+import java.util.Collections;
 import java.util.Map;
+
+import static java.lang.System.currentTimeMillis;
 
 
 /**
@@ -46,5 +49,15 @@ public class ConstantPayloadGenerator implements PayloadGenerator, Configurable 
   @Override
   public Map<String, String> getRequestHeaders() {
     return requestHeaders;
+  }
+
+  @Override
+  public Map<String, Object> getOffsets() {
+    return Collections.singletonMap("timestamp", currentTimeMillis());
+  }
+
+  @Override
+  public void setOffsets(Map<String, Object> offsets) {
+    // do nothing.
   }
 }

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/PayloadGenerator.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/PayloadGenerator.java
@@ -50,5 +50,19 @@ public interface PayloadGenerator {
    * @return The headers to be sent to the REST service.
    */
   Map<String, String> getRequestHeaders();
+
+  /**
+   * Get the input stream offsets for the current payload.
+   *
+   * @return The offsets.
+   */
+  Map<String, Object> getOffsets();
+
+  /**
+   * Set the input stream offsets.
+   *
+   * @param offsets The offsets.
+   */
+  void setOffsets(Map<String, Object> offsets);
 }
 

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProvider.java
@@ -17,7 +17,7 @@ import java.util.Map;
  */
 public abstract class AbstractValueProvider implements ValueProvider {
 
-  private Map<String, String> parameterMap = new HashMap<>();
+  protected Map<String, String> parameterMap = new HashMap<>();
 
 
   /**
@@ -79,6 +79,7 @@ public abstract class AbstractValueProvider implements ValueProvider {
    */
   @Override
   public void setParameters(Map<String, Object> params) {
+    parameterMap.clear();
     params.forEach((k, v) -> parameterMap.put(k, v.toString()));
   }
 }

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProvider.java
@@ -1,0 +1,84 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * This abstract class is a sensible base for value provider implementations.
+ * It tracks the parameter set in use and ensures that the same parameter will only be looked up once per update
+ * meaning it will have the same value throughout a payload.
+ */
+public abstract class AbstractValueProvider implements ValueProvider {
+
+  private Map<String, String> parameterMap = new HashMap<>();
+
+
+  /**
+   * Extract the values that will be used by the template engine from the last request-response cycle.
+   *
+   * @param request The last request made.
+   * @param response The last response received.
+   */
+  abstract void extractValues(Request request, Response response);
+
+  /**
+   * Get the value for a given key.
+   *
+   * @param key the key to lookup
+   * @return the value or null if the key is undefined.
+   */
+  abstract String getValue(String key);
+
+  /**
+   * This implementation doesn't udate
+   *
+   * @param request The last request made.
+   * @param response The last response received.
+   */
+  @Override
+  public void update(Request request, Response response) {
+    parameterMap.clear();
+    extractValues(request, response);
+  }
+
+  /**
+   * Returns the value of the given key, which will be looked up first in the System properties and then
+   * in environment variables.
+   *
+   * @return The defined value or null if te key is undefined.
+   */
+  @Override
+  public String lookupValue(String key) {
+    String value = parameterMap.getOrDefault(key, getValue(key));
+    parameterMap.put(key, value);
+    return value;
+  }
+
+  /**
+   * Get the map of keys to values that have been requested since the last update.
+   *
+   * @return The parameter map.
+   */
+  @Override
+  public Map<String, Object> getParameters() {
+    return Collections.unmodifiableMap(parameterMap);
+  }
+
+  /**
+   * Set the map of keys to values that will be used to generate the next template.
+   * Note that the update method may overwrite some or all of these mappings.
+   *
+   * @param params The parameter map.
+   */
+  @Override
+  public void setParameters(Map<String, Object> params) {
+    params.forEach((k, v) -> parameterMap.put(k, v.toString()));
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProvider.java
@@ -6,7 +6,6 @@ import com.tm.kafka.connect.rest.http.Response;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 
@@ -22,22 +21,25 @@ public abstract class AbstractValueProvider implements ValueProvider {
 
   /**
    * Extract the values that will be used by the template engine from the last request-response cycle.
+   * It is not necessary for parameters used by the value provider to come from the request or response,
+   * and in some cases this method may do nothing.
    *
    * @param request The last request made.
    * @param response The last response received.
    */
-  abstract void extractValues(Request request, Response response);
+  protected abstract void extractValues(Request request, Response response);
 
   /**
    * Get the value for a given key.
+   * This method is called if the key cannot be found in the current set of cached parameters.
    *
    * @param key the key to lookup
    * @return the value or null if the key is undefined.
    */
-  abstract String getValue(String key);
+  protected abstract String getValue(String key);
 
   /**
-   * This implementation doesn't udate
+   * Update the parameter values based on the last request and response.
    *
    * @param request The last request made.
    * @param response The last response received.
@@ -49,10 +51,9 @@ public abstract class AbstractValueProvider implements ValueProvider {
   }
 
   /**
-   * Returns the value of the given key, which will be looked up first in the System properties and then
-   * in environment variables.
+   * Returns the value of the given key.
    *
-   * @return The defined value or null if te key is undefined.
+   * @return The defined value or null if the key is undefined.
    */
   @Override
   public String lookupValue(String key) {
@@ -62,7 +63,7 @@ public abstract class AbstractValueProvider implements ValueProvider {
   }
 
   /**
-   * Get the map of keys to values that have been requested since the last update.
+   * Get the key-value pairs that have been requested since the last update.
    *
    * @return The parameter map.
    */
@@ -73,7 +74,8 @@ public abstract class AbstractValueProvider implements ValueProvider {
 
   /**
    * Set the map of keys to values that will be used to generate the next template.
-   * Note that the update method may overwrite some or all of these mappings.
+   * Note that the update method will overwrite these mappings.
+   * This method would normally be used to set initial state.
    *
    * @param params The parameter map.
    */

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/EnvironmentValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/EnvironmentValueProvider.java
@@ -4,8 +4,6 @@ package com.tm.kafka.connect.rest.http.payload.templated;
 import com.tm.kafka.connect.rest.http.Request;
 import com.tm.kafka.connect.rest.http.Response;
 
-import java.util.Map;
-
 
 /**
  * Lookup values used to populate dynamic payloads.
@@ -15,8 +13,14 @@ import java.util.Map;
  */
 public class EnvironmentValueProvider extends AbstractValueProvider {
 
+  /**
+   * This method does nothing as none of the values used by this class are based on the request or response.
+   *
+   * @param request The last request made.
+   * @param response The last response received.
+   */
   @Override
-  void extractValues(Request request, Response response) {
+  protected void extractValues(Request request, Response response) {
     // Do nothing
   }
 
@@ -27,7 +31,7 @@ public class EnvironmentValueProvider extends AbstractValueProvider {
    * @return The defined value or null if te key is undefined.
    */
   @Override
-  String getValue(String key) {
+  protected String getValue(String key) {
     String value = System.getProperty(key);
     return (value != null) ? value : System.getenv(key);
   }

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/EnvironmentValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/EnvironmentValueProvider.java
@@ -1,0 +1,34 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+
+import java.util.Map;
+
+
+/**
+ * Lookup values used to populate dynamic payloads.
+ * These values will be substituted into the payload template.
+ *
+ * This implementation looks up values in the System properties and then in environment variables.
+ */
+public class EnvironmentValueProvider extends AbstractValueProvider {
+
+  @Override
+  void extractValues(Request request, Response response) {
+    // Do nothing
+  }
+
+  /**
+   * Returns the value of the given key, which will be looked up first in the System properties and then
+   * in environment variables.
+   *
+   * @return The defined value or null if te key is undefined.
+   */
+  @Override
+  String getValue(String key) {
+    String value = System.getProperty(key);
+    return (value != null) ? value : System.getenv(key);
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProvider.java
@@ -17,7 +17,8 @@ import java.util.regex.Pattern;
  * Lookup values used to populate dynamic payloads.
  * These values will be substituted into the payload template.
  *
- * This implementation looks up values in the System properties and then in environment variables.
+ * This implementation uses RegExes to extract values from the HTTP response,
+ * and if not found looks them up in the System properties and then in environment variables.
  */
 public class RegexResponseValueProvider extends EnvironmentValueProvider implements Configurable {
 

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProvider.java
@@ -1,0 +1,93 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.RestSourceTask;
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import org.apache.kafka.common.Configurable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lookup values used to populate dynamic payloads.
+ * These values will be substituted into the payload template.
+ *
+ * This implementation looks up values in the System properties and then in environment variables.
+ */
+public class RegexResponseValueProvider extends EnvironmentValueProvider implements Configurable {
+
+  private static Logger log = LoggerFactory.getLogger(RegexResponseValueProvider.class);
+
+  public static final String MULTI_VALUE_SEPARATOR = ",";
+
+  private Map<String, Pattern> patterns;
+  private Map<String, String> values;
+
+
+  @Override
+  public void configure(Map<String, ?> props) {
+    final RegexResponseValueProviderConfig config = new RegexResponseValueProviderConfig(props);
+
+    patterns = new HashMap<>(config.getResponseVariableNames().size());
+    config.getResponseVariableRegexs().forEach((k,v) -> patterns.put(k, Pattern.compile(v)));
+
+    values = new HashMap<>(patterns.size());
+  }
+
+  /**
+   * Extract values from the response using the regexs
+   *
+   * @param request The last request made.
+   * @param response The last response received.
+   */
+  @Override
+  void extractValues(Request request, Response response) {
+    String resp = response.getPayload();
+    patterns.forEach((key, pat) -> values.put(key, extractValue(key, resp, pat)));
+  }
+
+  /**
+   * Returns the value of the given key, which will be looked up first in the System properties and then
+   * in environment variables.
+   *
+   * @return The defined value or null if te key is undefined.
+   */
+  String getValue(String key) {
+    String value = values.get(key);
+    return value != null ? value : super.getValue(key);
+  }
+
+  private String extractValue(String key, String resp, Pattern pattern) {
+    Matcher matcher = pattern.matcher(resp);
+    StringBuilder values = new StringBuilder();
+    // Iterate over each place where the regex matches
+    while(matcher.find()) {
+      if(values.length() > 0) {
+        values.append(MULTI_VALUE_SEPARATOR);
+      }
+      if(matcher.groupCount() == 0) {
+        // if the regex has no groups then the whole thing is the value
+        values.append(matcher.group());
+      } else {
+        // If the regex has one or more groups then append them in order
+        for(int g = 1; g <= matcher.groupCount(); g++) {
+          if(values.length() > 0) {
+            values.append(MULTI_VALUE_SEPARATOR);
+          }
+          values.append(matcher.group(g));
+        }
+      }
+    }
+
+    String value = (values.length() != 0) ? values.toString() : null;
+
+    log.info("Variable {} was assigned the value {}", key, value);
+
+    return value;
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProviderConfig.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProviderConfig.java
@@ -1,0 +1,88 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class RegexResponseValueProviderConfig extends AbstractConfig {
+
+  public static final String RESPONSE_VAR_NAMES_CONFIG = "rest.source.response.var.names";
+  private static final String RESPONSE_VAR_NAMES_DOC = "A list of variable names to be used for substitution into the " +
+    "HTTP request template.  A regex must be defined for each variable and will be run against the HTTP response to " +
+    "extract values for the next HTTP request.";
+  private static final String RESPONSE_VAR_NAMES_DISPLAY = "Template variables for REST source connector.";
+  private static final List<String> RESPONSE_VAR_NAMES_DEFAULT = Collections.EMPTY_LIST;
+
+  public static final String RESPONSE_VAR_REGEX_CONFIG = "rest.source.response.var.%s.regex";
+  private static final String RESPONSE_VAR_REGEX_DOC = "The regex used to extract the %s variable from the HTTP response. " +
+    "This parameter can then be used in the next templated HTTP request.";
+  private static final String RESPONSE_VAR_REGEX_DISPLAY = "Regex for %s variable for REST source connector.";
+  private static final Object RESPONSE_VAR_REGEX_DEFAULT = ConfigDef.NO_DEFAULT_VALUE;
+
+
+  private final Map<String, String> responseVariableRegexs;
+
+
+  protected RegexResponseValueProviderConfig(ConfigDef config, Map<String, ?> unparsedConfig) {
+    super(config, unparsedConfig);
+
+    List<String> variableNames = getResponseVariableNames();
+    responseVariableRegexs = new HashMap<>(variableNames.size());
+    variableNames.forEach(key -> responseVariableRegexs.put(key, getString(String.format(RESPONSE_VAR_REGEX_CONFIG, key))));
+  }
+
+  public RegexResponseValueProviderConfig(Map<String, ?> unparsedConfig) {
+    this(conf(unparsedConfig), unparsedConfig);
+  }
+
+  public static ConfigDef conf(Map<String, ?> unparsedConfig) {
+    String group = "REST_HTTP";
+    int orderInGroup = 0;
+    ConfigDef config = new ConfigDef()
+      .define(RESPONSE_VAR_NAMES_CONFIG,
+        Type.LIST,
+        RESPONSE_VAR_NAMES_DEFAULT,
+        Importance.LOW,
+        RESPONSE_VAR_NAMES_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        RESPONSE_VAR_NAMES_DISPLAY)
+      ;
+
+    // This is a bit hacky and there may be a better way of doing it, but I don't know it.
+    // We need to create config items dynamically, based on the parameter names,
+    // so we need a 2 pass parse of the config.
+    List<String> varNames = (List) config.parse(unparsedConfig).get(RESPONSE_VAR_NAMES_CONFIG);
+
+    for(String varName : varNames) {
+      config.define(String.format(RESPONSE_VAR_REGEX_CONFIG, varName),
+        Type.STRING,
+        RESPONSE_VAR_REGEX_DEFAULT,
+        Importance.HIGH,
+        String.format(RESPONSE_VAR_REGEX_DOC, varName),
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        String.format(RESPONSE_VAR_REGEX_DISPLAY, varName));
+    }
+
+    return(config);
+  }
+
+  public List<String> getResponseVariableNames() {
+    return this.getList(RESPONSE_VAR_NAMES_CONFIG);
+  }
+
+  public Map<String, String> getResponseVariableRegexs() {
+    return responseVariableRegexs;
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplateEngine.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplateEngine.java
@@ -1,0 +1,27 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+
+import java.util.Map;
+
+
+/**
+ * Template engine is responsible for converting a template into a series of outputs, based on a series of context
+ * entries.
+ * <p>
+ * Note: This is a Service Provider Interface (SPI)
+ * All implementations should be listed in
+ * META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.TemplateEngine
+ */
+public interface TemplateEngine {
+
+  /**
+   * Get a particular interpretation of the template based on the values in the given coutext.
+   *
+   * @param context The source from which values are taken.
+   * @return A completed template where all appliccable placeholders have been replaced with values.
+   */
+  String renderTemplate(String template, ValueProvider context);
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGenerator.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGenerator.java
@@ -1,0 +1,91 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import com.tm.kafka.connect.rest.http.payload.PayloadGenerator;
+import org.apache.kafka.common.Configurable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * This is a payload generator that attempts to fill in the placeholders in a template using values from a
+ * ValueProvider instance.
+ */
+public class TemplatedPayloadGenerator implements PayloadGenerator, Configurable {
+
+  private static Logger log = LoggerFactory.getLogger(RegexResponseValueProvider.class);
+
+  private String requestBodyTemplate;
+  private Map<String, String> requestParameterTemplates;
+  private Map<String, String> requestParameterValues;
+  private String requestBodyValue;
+  private Map<String, String> requestHeaderTemplates;
+  private Map<String, String> requestHeaderValues;
+  private ValueProvider valueProvider;
+  private TemplateEngine templateEngine;
+
+
+  @Override
+  public void configure(Map<String, ?> props) {
+    final TemplatedPayloadGeneratorConfig config = new TemplatedPayloadGeneratorConfig(props);
+
+    requestBodyTemplate = config.getRequestBodyTemplate();
+    requestParameterTemplates = config.getRequestParameterTemplates();
+    requestHeaderTemplates = config.getRequestHeaderTemplates();
+
+    requestParameterValues = new HashMap<>(requestParameterTemplates.size());
+    requestHeaderValues = new HashMap<>(requestHeaderTemplates.size());
+
+    valueProvider = config.getValueProvider();
+    templateEngine = config.getTemplateEngine();
+  }
+
+  @Override
+  public boolean update(Request request, Response response) {
+    valueProvider.update(request,response);
+
+    requestBodyValue = templateEngine.renderTemplate(requestBodyTemplate, valueProvider);
+    requestParameterTemplates
+      .forEach((k, v) -> requestParameterValues.put(k, templateEngine.renderTemplate(v, valueProvider)));
+    requestHeaderTemplates
+      .forEach((k, v) -> requestHeaderValues.put(k, templateEngine.renderTemplate(v, valueProvider)));
+
+    log.info("Body to be sent: {}", requestBodyValue);
+    log.info("Parameters to be sent: {}", Arrays.toString(requestParameterValues.entrySet().toArray()));
+    log.info("Headers to be sent: {}", Arrays.toString(requestHeaderValues.entrySet().toArray()));
+
+    // False = Wait for the next poll cycle before calling again.
+    return false;
+  }
+
+  @Override
+  public String getRequestBody() {
+    return requestBodyValue;
+  }
+
+  @Override
+  public Map<String, String> getRequestParameters() {
+    return requestParameterValues;
+  }
+
+  @Override
+  public Map<String, String> getRequestHeaders() {
+    return requestHeaderValues;
+  }
+
+  @Override
+  public Map<String, Object> getOffsets() {
+    return valueProvider.getParameters();
+  }
+
+  @Override
+  public void setOffsets(Map<String, Object> offsets) {
+    valueProvider.setParameters(offsets);
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGenerator.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGenerator.java
@@ -44,21 +44,15 @@ public class TemplatedPayloadGenerator implements PayloadGenerator, Configurable
 
     valueProvider = config.getValueProvider();
     templateEngine = config.getTemplateEngine();
+
+    populateValues();
   }
 
   @Override
   public boolean update(Request request, Response response) {
     valueProvider.update(request,response);
 
-    requestBodyValue = templateEngine.renderTemplate(requestBodyTemplate, valueProvider);
-    requestParameterTemplates
-      .forEach((k, v) -> requestParameterValues.put(k, templateEngine.renderTemplate(v, valueProvider)));
-    requestHeaderTemplates
-      .forEach((k, v) -> requestHeaderValues.put(k, templateEngine.renderTemplate(v, valueProvider)));
-
-    log.info("Body to be sent: {}", requestBodyValue);
-    log.info("Parameters to be sent: {}", Arrays.toString(requestParameterValues.entrySet().toArray()));
-    log.info("Headers to be sent: {}", Arrays.toString(requestHeaderValues.entrySet().toArray()));
+    populateValues();
 
     // False = Wait for the next poll cycle before calling again.
     return false;
@@ -87,5 +81,18 @@ public class TemplatedPayloadGenerator implements PayloadGenerator, Configurable
   @Override
   public void setOffsets(Map<String, Object> offsets) {
     valueProvider.setParameters(offsets);
+    populateValues();
+  }
+
+  private void populateValues() {
+    requestBodyValue = templateEngine.renderTemplate(requestBodyTemplate, valueProvider);
+    requestParameterTemplates
+      .forEach((k, v) -> requestParameterValues.put(k, templateEngine.renderTemplate(v, valueProvider)));
+    requestHeaderTemplates
+      .forEach((k, v) -> requestHeaderValues.put(k, templateEngine.renderTemplate(v, valueProvider)));
+
+    log.info("Body to be sent: {}", requestBodyValue);
+    log.info("Parameters to be sent: {}", Arrays.toString(requestParameterValues.entrySet().toArray()));
+    log.info("Headers to be sent: {}", Arrays.toString(requestHeaderValues.entrySet().toArray()));
   }
 }

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGeneratorConfig.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGeneratorConfig.java
@@ -1,0 +1,185 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.config.InstanceOfValidator;
+import com.tm.kafka.connect.rest.config.ServiceProviderInterfaceRecommender;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class TemplatedPayloadGeneratorConfig extends AbstractConfig {
+
+  public static final String REQUEST_BODY_TEMPLATE_CONFIG = "rest.source.body.template";
+  private static final String REQUEST_BODY_TEMPLATE_DOC = "The template used to generate the HTTP request body that will be " +
+    "sent with each REST request. This parameter is not appliccable to GET requests.";
+  private static final String REQUEST_BODY_TEMPLATE_DISPLAY = "Request body template for REST source connector.";
+  private static final String REQUEST_BODY_TEMPLATE_DEFAULT = "";
+
+  public static final String REQUEST_PARAMETER_NAMES_CONFIG = "rest.source.param.names";
+  private static final String REQUEST_PARAMETER_NAMES_DOC = "The HTTP request parameter names that will be sent with each " +
+    "REST request. The parameter values should each be defined by a rest.source.param.<param_name>.value entry.";
+  private static final String REQUEST_PARAMETER_NAMES_DISPLAY = "HTTP request parameter names for REST source connector.";
+  private static final List<String> REQUEST_PARAMETER_NAMES_DEFAULT = Collections.EMPTY_LIST;
+
+  public static final String REQUEST_PARAMETER_TEMPLATE_CONFIG = "rest.source.param.%s.template";
+  private static final String REQUEST_PARAMETER_TEMPLATE_DOC = "Template used to generate the %s parameter which will " +
+    "be passed with each REST request.  This value will be URLEncoded before transmission.";
+  private static final String REQUEST_PARAMETER_TEMPLATE_DISPLAY = "Template for %s parameter for REST source connector.";
+  private static final Object REQUEST_PARAMETER_TEMPLATE_DEFAULT = ConfigDef.NO_DEFAULT_VALUE;
+
+  public static final String REQUEST_HEADERS_TEMPLATE_CONFIG = "rest.source.headers.template";
+  private static final String REQUEST_HEADERS_TEMPLATE_DISPLAY = "The Templates used to generate HTTP request headers " +
+    "that will be sent with each REST request. The headers should be of the form 'key:value'.";
+  private static final String REQUEST_HEADERS_TEMPLATE_DOC = "Request headers template for REST source connector.";
+  private static final List<String> REQUEST_HEADERS_TEMPLATE_DEFAULT = Collections.EMPTY_LIST;
+
+  public static final String VALUE_PROVIDER_CONFIG = "rest.source.payload.value.provider";
+  private static final String VALUE_PROVIDER_DOC = "The class that will provide the values to be substituted into " +
+    "the payload template by the payload generator.";
+  private static final String VALUE_PROVIDER_DISPLAY = "Payload Value Provider class for REST source connector.";
+  private static final Class<? extends ValueProvider> VALUE_PROVIDER_DEFAULT =
+    EnvironmentValueProvider.class;
+
+  public static final String TEMPLATE_ENGINE_CONFIG = "rest.source.payload.template.engine";
+  private static final String TEMPLATE_ENGINE_DOC = "The template engine that will process the template and " +
+    "substitute values to generate an actual payload string.";
+  private static final String TEMPLATE_ENGINE_DISPLAY = "Payload Template Engine class for REST source connector.";
+  private static final Class<? extends TemplateEngine> TEMPLATE_ENGINE_DEFAULT =
+    VelocityTemplateEngine.class;
+
+  private final Map<String, String> requestParameterTemplates;
+  private final Map<String, String> requestHeaderTemplates;
+  private final ValueProvider valueProvider;
+  private final TemplateEngine templateEngine;
+
+
+  protected TemplatedPayloadGeneratorConfig(ConfigDef config, Map<String, ?> unparsedConfig) {
+    super(config, unparsedConfig);
+
+    valueProvider = this.getConfiguredInstance(VALUE_PROVIDER_CONFIG, ValueProvider.class);
+    templateEngine = this.getConfiguredInstance(TEMPLATE_ENGINE_CONFIG, TemplateEngine.class);
+
+    List<String> paramNames = getRequestParameterNames();
+    requestParameterTemplates = new HashMap<>(paramNames.size());
+    paramNames.forEach(key -> requestParameterTemplates.put(key, getString(String.format(REQUEST_PARAMETER_TEMPLATE_CONFIG, key))));
+
+    requestHeaderTemplates = getList(REQUEST_HEADERS_TEMPLATE_CONFIG).stream()
+      .map(a -> a.split(":", 2))
+      .collect(Collectors.toMap(a -> a[0], a -> a[1]));
+  }
+
+  public TemplatedPayloadGeneratorConfig(Map<String, ?> unparsedConfig) {
+    this(conf(unparsedConfig), unparsedConfig);
+  }
+
+  public static ConfigDef conf(Map<String, ?> unparsedConfig) {
+    String group = "REST_HTTP";
+    int orderInGroup = 0;
+    ConfigDef config = new ConfigDef()
+      .define(VALUE_PROVIDER_CONFIG,
+        Type.CLASS,
+        VALUE_PROVIDER_DEFAULT,
+        new InstanceOfValidator(ValueProvider.class),
+        Importance.HIGH,
+        VALUE_PROVIDER_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        VALUE_PROVIDER_DISPLAY,
+        new ServiceProviderInterfaceRecommender(ValueProvider.class))
+
+      .define(TEMPLATE_ENGINE_CONFIG,
+        Type.CLASS,
+        TEMPLATE_ENGINE_DEFAULT,
+        new InstanceOfValidator(TemplateEngine.class),
+        Importance.HIGH,
+        TEMPLATE_ENGINE_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        TEMPLATE_ENGINE_DISPLAY,
+        new ServiceProviderInterfaceRecommender(TemplateEngine.class))
+
+      .define(REQUEST_BODY_TEMPLATE_CONFIG,
+        Type.STRING,
+        REQUEST_BODY_TEMPLATE_DEFAULT,
+        Importance.LOW,
+        REQUEST_BODY_TEMPLATE_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.LONG,
+        REQUEST_BODY_TEMPLATE_DISPLAY)
+
+      .define(REQUEST_PARAMETER_NAMES_CONFIG,
+        Type.LIST,
+        REQUEST_PARAMETER_NAMES_DEFAULT,
+        Importance.LOW,
+        REQUEST_PARAMETER_NAMES_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        REQUEST_PARAMETER_NAMES_DISPLAY)
+
+      .define(REQUEST_HEADERS_TEMPLATE_CONFIG,
+        Type.LIST,
+        REQUEST_HEADERS_TEMPLATE_DEFAULT,
+        Importance.LOW,
+        REQUEST_HEADERS_TEMPLATE_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        REQUEST_HEADERS_TEMPLATE_DISPLAY)
+      ;
+
+    // This is a bit hacky and there may be a better way of doing it, but I don't know it.
+    // We need to create config items dynamically, based on the parameter names,
+    // so we need a 2 pass parse of the config.
+    List<String> paramNames = (List) config.parse(unparsedConfig).get(REQUEST_PARAMETER_NAMES_CONFIG);
+
+    for(String paramName : paramNames) {
+      config.define(String.format(REQUEST_PARAMETER_TEMPLATE_CONFIG, paramName),
+        Type.STRING,
+        REQUEST_PARAMETER_TEMPLATE_DEFAULT,
+        Importance.HIGH,
+        String.format(REQUEST_PARAMETER_TEMPLATE_DOC, paramName),
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        String.format(REQUEST_PARAMETER_TEMPLATE_DISPLAY, paramName));
+    }
+
+    return(config);
+  }
+
+  public String getRequestBodyTemplate() {
+    return this.getString(REQUEST_BODY_TEMPLATE_CONFIG);
+  }
+
+  public List<String> getRequestParameterNames() {
+    return this.getList(REQUEST_PARAMETER_NAMES_CONFIG);
+  }
+
+  public Map<String, String> getRequestParameterTemplates() {
+    return requestParameterTemplates;
+  }
+
+  public Map<String, String> getRequestHeaderTemplates() {
+    return requestHeaderTemplates;
+  }
+
+  public ValueProvider getValueProvider() {
+    return valueProvider;
+  }
+
+  public TemplateEngine getTemplateEngine() {
+    return templateEngine;
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/ValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/ValueProvider.java
@@ -1,0 +1,49 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+
+import java.util.Map;
+
+
+/**
+ * Lookup values used to populate dynamic payloads.
+ * These values will be substituted into the payload template.
+ * <p>
+ * Note: This is a Service Provider Interface (SPI)
+ * All implementations should be listed in
+ * META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.ValueProvider
+ */
+public interface ValueProvider {
+
+  /**
+   * Update the values being provided in the light of the most recent request and response
+   *
+   * @param request The last request made.
+   * @param response The last response received.
+   */
+  void update(Request request, Response response);
+
+  /**
+   * Returns the value of the given key, or null if the key s undefined.
+   *
+   * @return The value of the key.
+   */
+  String lookupValue(String key);
+
+  /**
+   * Get the map of keys to values that have been requested since the last update.
+   *
+   * @return The parameter map.
+   */
+  Map<String, Object> getParameters();
+
+  /**
+   * Set the map of keys to values that will be used to generate the next template.
+   * Note that the update method may overwrite some or all of these mappings.
+   *
+   * @param params The parameter map.
+   */
+  void setParameters(Map<String, Object> params);
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/VelocityTemplateEngine.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/VelocityTemplateEngine.java
@@ -1,0 +1,75 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import org.apache.velocity.app.Velocity;
+import org.apache.velocity.context.AbstractContext;
+
+import java.io.StringWriter;
+
+
+/**
+ * This template engine uses MessageFormat to convert a template into a series of outputs, based on a series of context
+ * entries.
+ */
+public class VelocityTemplateEngine implements TemplateEngine {
+
+  private VelocityContextAdapter contextAdapter = new VelocityContextAdapter();
+
+
+  public VelocityTemplateEngine() {
+    Velocity.init();
+  }
+
+  /**
+   * Get a particular interpretation of the template based on the values in the given context.
+   *
+   * @param context The source from which values are taken.
+   * @return A completed template where all appliccable placeholders have been replaced with values.
+   */
+  @Override
+  public String renderTemplate(String template, ValueProvider context) {
+    StringWriter writer = new StringWriter();
+    contextAdapter.setValueProvider(context);
+    Velocity.evaluate(contextAdapter, writer, "", template);
+    return writer.toString();
+  }
+
+
+  /**
+   * This is an adapter that allows a ValueProvider to be used as a Velocity Context object.
+   */
+  private static class VelocityContextAdapter extends AbstractContext {
+
+    private ValueProvider context;
+
+
+    public void setValueProvider(ValueProvider context) {
+      this.context = context;
+    }
+
+    @Override
+    public Object internalGet(String key) {
+      return context.lookupValue(key);
+    }
+
+    @Override
+    public Object internalPut(String s, Object o) {
+      throw new UnsupportedOperationException("An attempt was made to alter to a read-only context");
+    }
+
+    @Override
+    public boolean internalContainsKey(String key) {
+      return context.lookupValue(key) != null;
+    }
+
+    @Override
+    public String[] internalGetKeys() {
+      return new String[0];
+    }
+
+    @Override
+    public Object internalRemove(String s) {
+      throw new UnsupportedOperationException("An attempt was made to alter to a read-only context");
+    }
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProvider.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProvider.java
@@ -1,0 +1,115 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import org.apache.kafka.common.Configurable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.xpath.*;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Lookup values used to populate dynamic payloads.
+ * These values will be substituted into the payload template.
+ *
+ * This implementation uses XPath to extract values from an XML HTTP response,
+ * and if not found looks them up in the System properties and then in environment variables.
+ */
+public class XPathResponseValueProvider extends EnvironmentValueProvider implements Configurable {
+
+  private static Logger log = LoggerFactory.getLogger(XPathResponseValueProvider.class);
+
+  public static final String MULTI_VALUE_SEPARATOR = ",";
+
+  private static final XPathFactory X_PATH_FACTORY = XPathFactory.newInstance();
+
+  private Map<String, XPathExpression> expressions;
+
+
+  /**
+   * Configure this instance after creation.
+   *
+   * @param props The configuration properties
+   */
+  @Override
+  public void configure(Map<String, ?> props) {
+    final XPathResponseValueProviderConfig config = new XPathResponseValueProviderConfig(props);
+    setExpressions(config.getResponseVariableXPaths());
+  }
+
+  /**
+   * Extract values from the response using the XPaths
+   *
+   * @param request The last request made.
+   * @param response The last response received.
+   */
+  @Override
+  protected void extractValues(Request request, Response response) {
+    String resp = response.getPayload();
+    expressions.forEach((key, expr) -> parameterMap.put(key, extractValue(key, resp, expr)));
+  }
+
+  /**
+   * Set the XPaths to be used for value extraction.
+   *
+   * @param xPaths A map of key names to XPath expressions
+   */
+  protected void setExpressions(Map<String, String> xPaths) {
+    expressions = new HashMap<>(xPaths.size());
+    parameterMap = new HashMap<>(expressions.size());
+    xPaths.forEach(this::addXPath);
+  }
+
+  /**
+   * Extract the value for a given key.
+   * Where the XPath yeilds more than one result a comma seperated list will be returned.
+   *
+   * @param key The name of the key
+   * @param resp The response to extract a value from
+   * @param expression The compiled XPath used to find the value
+   * @return Return the value, or null if it wasn't found
+   */
+  private String extractValue(String key, String resp, XPathExpression expression) {
+    InputSource inputXML = new InputSource(new StringReader(resp));
+    StringBuilder values = new StringBuilder();
+    try {
+      NodeList nodes = (NodeList) expression.evaluate(inputXML, XPathConstants.NODESET);
+
+      for(int i = 0; i < nodes.getLength(); i++) {
+        if(values.length() > 0) {
+          values.append(MULTI_VALUE_SEPARATOR);
+        }
+        Node node = nodes.item(i);
+        values.append(node.getTextContent());
+      }
+
+      String value = (values.length() != 0) ? values.toString() : null;
+      log.info("Variable {} was assigned the value {}", key, value);
+      return value;
+    } catch (XPathExpressionException ex) {
+      log.error("The XPath expression '" + expression.toString() + "' could not be evaluated against: " + resp, ex);
+      return null;
+    } catch (DOMException ex) {
+      log.error("The result(s) were too big when XPath expression '" + expression.toString()
+        + "' was evaluated against: " + resp, ex);
+      return null;
+    }
+  }
+
+  private void addXPath(String key, String xPath) {
+    try {
+      expressions.put(key, X_PATH_FACTORY.newXPath().compile(xPath));
+    } catch (XPathExpressionException ex) {
+      log.error("The XPath expression '" + xPath + "' could not be compiled", ex);
+    }
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderConfig.java
+++ b/kafka-connect-rest-plugin/src/main/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderConfig.java
@@ -1,0 +1,88 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class XPathResponseValueProviderConfig extends AbstractConfig {
+
+  public static final String RESPONSE_VAR_NAMES_CONFIG = "rest.source.response.var.names";
+  private static final String RESPONSE_VAR_NAMES_DOC = "A list of variable names to be used for substitution into the " +
+    "HTTP request template.  An XPath expression must be defined for each variable and will be run against the HTTP " +
+    "response to extract values for the next HTTP request.";
+  private static final String RESPONSE_VAR_NAMES_DISPLAY = "Template variables for REST source connector.";
+  private static final List<String> RESPONSE_VAR_NAMES_DEFAULT = Collections.EMPTY_LIST;
+
+  public static final String RESPONSE_VAR_XPATH_CONFIG = "rest.source.response.var.%s.xpath";
+  private static final String RESPONSE_VAR_XPATH_DOC = "The XPath expression used to extract the %s variable from the " +
+    "HTTP response. This parameter can then be used in the next templated HTTP request.";
+  private static final String RESPONSE_VAR_XPATH_DISPLAY = "XPath for %s variable for REST source connector.";
+  private static final Object RESPONSE_VAR_XPATH_DEFAULT = ConfigDef.NO_DEFAULT_VALUE;
+
+
+  private final Map<String, String> responseVariableXPaths;
+
+
+  protected XPathResponseValueProviderConfig(ConfigDef config, Map<String, ?> unparsedConfig) {
+    super(config, unparsedConfig);
+
+    List<String> variableNames = getResponseVariableNames();
+    responseVariableXPaths = new HashMap<>(variableNames.size());
+    variableNames.forEach(key -> responseVariableXPaths.put(key, getString(String.format(RESPONSE_VAR_XPATH_CONFIG, key))));
+  }
+
+  public XPathResponseValueProviderConfig(Map<String, ?> unparsedConfig) {
+    this(conf(unparsedConfig), unparsedConfig);
+  }
+
+  public static ConfigDef conf(Map<String, ?> unparsedConfig) {
+    String group = "REST_HTTP";
+    int orderInGroup = 0;
+    ConfigDef config = new ConfigDef()
+      .define(RESPONSE_VAR_NAMES_CONFIG,
+        Type.LIST,
+        RESPONSE_VAR_NAMES_DEFAULT,
+        Importance.LOW,
+        RESPONSE_VAR_NAMES_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        RESPONSE_VAR_NAMES_DISPLAY)
+      ;
+
+    // This is a bit hacky and there may be a better way of doing it, but I don't know it.
+    // We need to create config items dynamically, based on the parameter names,
+    // so we need a 2 pass parse of the config.
+    List<String> varNames = (List) config.parse(unparsedConfig).get(RESPONSE_VAR_NAMES_CONFIG);
+
+    for(String varName : varNames) {
+      config.define(String.format(RESPONSE_VAR_XPATH_CONFIG, varName),
+        Type.STRING,
+        RESPONSE_VAR_XPATH_DEFAULT,
+        Importance.HIGH,
+        String.format(RESPONSE_VAR_XPATH_DOC, varName),
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.SHORT,
+        String.format(RESPONSE_VAR_XPATH_DISPLAY, varName));
+    }
+
+    return(config);
+  }
+
+  public List<String> getResponseVariableNames() {
+    return this.getList(RESPONSE_VAR_NAMES_CONFIG);
+  }
+
+  public Map<String, String> getResponseVariableXPaths() {
+    return responseVariableXPaths;
+  }
+}

--- a/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.PayloadGenerator
+++ b/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.PayloadGenerator
@@ -1,3 +1,4 @@
 # This file lists the available implementations of the PayloadGenerator SPI interface
 # This interface provides HTTP payload generation functionality
 com.tm.kafka.connect.rest.http.payload.ConstantPayloadGenerator
+com.tm.kafka.connect.rest.http.payload.templated.TemplatedPayloadGenerator

--- a/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.TemplateEngine
+++ b/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.TemplateEngine
@@ -1,0 +1,3 @@
+# This file lists the available implementations of the TemplateEngine SPI interface
+# This interface provides template interpretation functionality for templated payloads
+com.tm.kafka.connect.rest.http.payload.templated.VelocityTemplateEngine

--- a/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.ValueProvider
+++ b/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.ValueProvider
@@ -1,0 +1,4 @@
+# This file lists the available implementations of the ValueProvider SPI interface
+# This interface provides initial values for templated payloads functionality
+com.tm.kafka.connect.rest.http.payload.templated.EnvironmentValueProvider
+com.tm.kafka.connect.rest.http.payload.templated.RegexResponseValueProvider

--- a/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.ValueProvider
+++ b/kafka-connect-rest-plugin/src/main/resources/META-INF/services/com.tm.kafka.connect.rest.http.payload.templated.ValueProvider
@@ -2,3 +2,4 @@
 # This interface provides initial values for templated payloads functionality
 com.tm.kafka.connect.rest.http.payload.templated.EnvironmentValueProvider
 com.tm.kafka.connect.rest.http.payload.templated.RegexResponseValueProvider
+com.tm.kafka.connect.rest.http.payload.templated.XPathResponseValueProvider

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/RestTaskTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/RestTaskTest.java
@@ -14,12 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -87,17 +82,7 @@ public class RestTaskTest {
     List<SourceRecord> messages;
 
     sourceTask = new RestSourceTask();
-    SourceTaskContext context1 = new SourceTaskContext() {
-      @Override
-      public Map<String, String> configs() {
-        return null;
-      }
-
-      @Override
-      public OffsetStorageReader offsetStorageReader() {
-        return null;
-      }
-    };
+    SourceTaskContext context1 = new MockSourceTaskContext();
     sourceTask.initialize(context1);
     sourceTask.start(props);
     messages = sourceTask.poll();
@@ -210,6 +195,29 @@ public class RestTaskTest {
       return localPort;
     } catch (Exception e) {
       throw new RuntimeException("Failed to get a free PORT", e);
+    }
+  }
+
+  protected static class MockSourceTaskContext implements SourceTaskContext {
+    @Override
+    public Map<String, String> configs() {
+      return null;
+    }
+
+    @Override
+    public OffsetStorageReader offsetStorageReader() {
+      return new OffsetStorageReader() {
+
+        @Override
+        public <T> Map<String, Object> offset(Map<String, T> map) {
+          return null;
+        }
+
+        @Override
+        public <T> Map<Map<String, T>, Map<String, Object>> offsets(Collection<Map<String, T>> collection) {
+          return null;
+        }
+      };
     }
   }
 

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/ConstantPayloadGeneratorTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/ConstantPayloadGeneratorTest.java
@@ -74,4 +74,17 @@ public class ConstantPayloadGeneratorTest {
     generator.configure(Collections.emptyMap());
     assertThat(generator.getRequestHeaders(), not(hasKey(anything())));
   }
+
+  @Test
+  public void testGetOffsets() {
+    generator.configure(CONFIG_PROPS);
+    assertThat(generator.getOffsets(), hasEntry(equalTo("timestamp"), instanceOf(Long.class)));
+  }
+
+  @Test
+  public void testSetOffsets() {
+    generator.configure(CONFIG_PROPS);
+    generator.setOffsets(null);
+    assertThat(generator.getOffsets(), notNullValue());
+  }
 }

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProviderTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProviderTest.java
@@ -67,12 +67,12 @@ public class AbstractValueProviderTest {
     }
 
     @Override
-    void extractValues(Request request, Response response) {
+    protected void extractValues(Request request, Response response) {
       parameterMap.put("body", response.getPayload());
     }
 
     @Override
-    String getValue(String key) {
+    protected String getValue(String key) {
       return "test".equals(key) ? "yeah" : null;
     }
   }

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProviderTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/AbstractValueProviderTest.java
@@ -1,0 +1,79 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class AbstractValueProviderTest {
+
+  Request request = mock(Request.class);
+  Response response = mock(Response.class);
+
+  AbstractValueProvider provider = new TestValueProvider();
+
+  @Test
+  public void update() {
+    when(response.getPayload()).thenReturn("OK");
+    provider.update(request, response);
+    Map<String, Object> parameters = provider.getParameters();
+    assertThat(parameters, hasEntry("body", "OK"));
+    assertThat(parameters.keySet(), hasSize(1));
+  }
+
+  @Test
+  public void lookupValue_alreadyFound() {
+    assertThat(provider.lookupValue("parameter"), equalTo("value"));
+  }
+
+  @Test
+  public void lookupValue_canBeFound() {
+    assertThat(provider.lookupValue("test"), equalTo("yeah"));
+  }
+
+  @Test
+  public void lookupValue_cannotBeFound() {
+    assertThat(provider.lookupValue("xxx"), nullValue());
+  }
+
+
+  @Test
+  public void getParameters() {
+    assertThat(provider.getParameters(), hasEntry("parameter", "value"));
+  }
+
+  @Test
+  public void setParameters() {
+    provider.setParameters(Collections.singletonMap("new-param", "val"));
+    Map<String, Object> parameters = provider.getParameters();
+    assertThat(parameters, hasEntry("new-param", "val"));
+    assertThat(parameters.keySet(), hasSize(1));
+  }
+
+
+  private static class TestValueProvider extends AbstractValueProvider {
+
+    public TestValueProvider() {
+      parameterMap.put("parameter", "value");
+    }
+
+    @Override
+    void extractValues(Request request, Response response) {
+      parameterMap.put("body", response.getPayload());
+    }
+
+    @Override
+    String getValue(String key) {
+      return "test".equals(key) ? "yeah" : null;
+    }
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/EnvironmentValueProviderTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/EnvironmentValueProviderTest.java
@@ -1,0 +1,37 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+
+public class EnvironmentValueProviderTest {
+
+  Request request = mock(Request.class);
+  Response response = mock(Response.class);
+
+  EnvironmentValueProvider provider = new EnvironmentValueProvider();
+
+  @Test
+  public void extractValues() {
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), not(hasKey(anything())));
+  }
+
+  @Test
+  public void getValue() {
+    System.setProperty("test", "yeah");
+    assertThat(provider.getValue("test"), equalTo("yeah"));
+  }
+
+  @Test
+  public void getValue_notDefined() {
+    System.clearProperty("test");
+    assertThat(provider.getValue("test"), nullValue());
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProviderConfigTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProviderConfigTest.java
@@ -1,0 +1,36 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.payload.ConstantPayloadGeneratorConfig;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertThat;
+
+
+public class RegexResponseValueProviderConfigTest {
+
+  @Test
+  public void testConfig() {
+    Map<String, Object> props = new HashMap<>();
+
+    props.put("rest.source.response.var.names", "key1, key2");
+    props.put("rest.source.response.var.key1.regex", ".*");
+    props.put("rest.source.response.var.key2.regex", "result: (\\d+)");
+
+    RegexResponseValueProviderConfig config = new RegexResponseValueProviderConfig(props);
+
+    assertThat(config.getResponseVariableNames(), contains("key1", "key2"));
+    assertThat(config.getResponseVariableRegexs(), allOf(
+      hasEntry("key1", ".*"),
+      hasEntry("key2", "result: (\\d+)")));
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProviderTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/RegexResponseValueProviderTest.java
@@ -1,0 +1,90 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class RegexResponseValueProviderTest {
+
+  Request request = mock(Request.class);
+  Response response = mock(Response.class);
+
+  RegexResponseValueProvider provider = new RegexResponseValueProvider();
+
+  @Test
+  public void extractValuesTest_wholeRegexFoundOnce() {
+    provider.setRegexes(Collections.singletonMap("name", ".+"));
+    when(response.getPayload()).thenReturn("Hello Big Ears");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", "Hello Big Ears"));
+  }
+
+  @Test
+  public void extractValuesTest_wholeRegexFoundMultiple() {
+    provider.setRegexes(Collections.singletonMap("name", "\\w+"));
+    when(response.getPayload()).thenReturn("Hello Big Ears");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", "Hello,Big,Ears"));
+  }
+
+  @Test
+  public void extractValuesTest_singleGroupFoundOnce() {
+    provider.setRegexes(Collections.singletonMap("name", "Hello (.+)"));
+    when(response.getPayload()).thenReturn("Hello Big Ears");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", "Big Ears"));
+  }
+
+  @Test
+  public void extractValuesTest_singleGroupFoundMultiple() {
+    provider.setRegexes(Collections.singletonMap("name", "Hello (\\w+)"));
+    when(response.getPayload()).thenReturn("Hello Noddy Hello Noddy");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", "Noddy,Noddy"));
+  }
+
+  @Test
+  public void extractValuesTest_multipleGroupsFound() {
+    provider.setRegexes(Collections.singletonMap("name", "Hello (\\w+) (\\w+)"));
+    when(response.getPayload()).thenReturn("Hello Big Ears");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", "Big,Ears"));
+  }
+
+  @Test
+  public void extractValuesTest_valueNotFound() {
+    provider.setRegexes(Collections.singletonMap("name", "Hello (.*)"));
+    when(response.getPayload()).thenReturn("Hi Big Ears");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", null));
+  }
+
+  @Test
+  public void lookupValueTest_extracted() {
+    provider.setRegexes(Collections.singletonMap("name", "Hello (.*)"));
+    when(response.getPayload()).thenReturn("Hello Big Ears");
+    provider.extractValues(request, response);
+    assertThat(provider.lookupValue("name"), equalTo("Big Ears"));
+  }
+
+  @Test
+  public void lookupValueTest_fromEnvironment() {
+    System.setProperty("test", "yeah");
+    assertThat(provider.lookupValue("test"), equalTo("yeah"));
+  }
+
+  @Test
+  public void lookupValueTest_notDefined() {
+    System.clearProperty("test");
+    assertThat(provider.lookupValue("test"), nullValue());
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGeneratorConfigTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGeneratorConfigTest.java
@@ -1,0 +1,36 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.payload.ConstantPayloadGeneratorConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertThat;
+
+
+public class TemplatedPayloadGeneratorConfigTest {
+
+  @Test
+  public void testConfig() {
+    Map<String, Object> props = new HashMap<>();
+
+    props.put("rest.source.body", "This is the body");
+    props.put("rest.source.param.names", "key1, key2");
+    props.put("rest.source.param.key1.value", "val1");
+    props.put("rest.source.param.key2.value", "val2");
+    props.put("rest.source.headers", Arrays.asList("Content-Type:application/json", "Accept:application/json"));
+
+    ConstantPayloadGeneratorConfig config = new ConstantPayloadGeneratorConfig(props);
+
+    assertThat(config.getRequestBody(), equalTo("This is the body"));
+    assertThat(config.getRequestParameters(), allOf(hasEntry("key1", "val1"), hasEntry("key2", "val2")));
+    assertThat(config.getRequestHeaders(), allOf(
+      hasEntry("Content-Type", "application/json"), hasEntry("Accept", "application/json")));
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGeneratorTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/TemplatedPayloadGeneratorTest.java
@@ -1,0 +1,115 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import com.tm.kafka.connect.rest.http.payload.ConstantPayloadGenerator;
+import com.tm.kafka.connect.rest.http.payload.ConstantPayloadGeneratorConfig;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.System.currentTimeMillis;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+
+public class TemplatedPayloadGeneratorTest {
+
+  private static String REQUEST_BODY_VAL = "{\"query\": \"select * from known_stars where name=${STAR_NAME}\"";
+
+  private static final Map<String, String> REQUEST_PARAM_VAL = Stream.of(new String[][] {
+    { "priority", "MAXIMUM" },
+    { "paged", "FALSE" },
+  }).collect(Collectors.toMap(d -> d[0], d -> d[1]));
+
+  private static final Map<String, String> REQUEST_HEADER_VAL = Stream.of(new String[][] {
+    { "Content-Type", "application/json" },
+    { "Accept", "application/json" },
+  }).collect(Collectors.toMap(d -> d[0], d -> d[1]));
+
+  private static final Map<String, String> CONFIG_PROPS = Stream.of(new String[][] {
+    { ConstantPayloadGeneratorConfig.REQUEST_BODY_CONFIG, REQUEST_BODY_VAL },
+    { ConstantPayloadGeneratorConfig.REQUEST_HEADERS_CONFIG, "Content-Type:application/json, Accept:application/json" },
+    { ConstantPayloadGeneratorConfig.REQUEST_PARAMETER_NAMES_CONFIG, "priority, paged" },
+    { String.format(ConstantPayloadGeneratorConfig.REQUEST_PARAMETER_VALUE_CONFIG, "priority"), "MAXIMUM" },
+    { String.format(ConstantPayloadGeneratorConfig.REQUEST_PARAMETER_VALUE_CONFIG, "paged"), "FALSE" },
+  }).collect(Collectors.toMap(d -> d[0], d -> d[1]));
+
+  private static final Request REQUEST = new Request("http://data.stars.org/query", "POST",
+    REQUEST_BODY_VAL, REQUEST_PARAM_VAL, REQUEST_HEADER_VAL);
+
+  private static final Response RESPONSE = new Response(200, Collections.emptyMap(), "LOTS of data");
+
+  private ConstantPayloadGenerator generator;
+
+  @Before
+  public void before() {
+    generator = new ConstantPayloadGenerator();
+  }
+
+
+  @Test
+  public void testUpdate() {
+    generator.configure(CONFIG_PROPS);
+    assertThat(generator.update(REQUEST, RESPONSE), Matchers.equalTo(false));
+  }
+
+  @Test
+  public void testGetRequestBody() {
+    generator.configure(CONFIG_PROPS);
+    System.setProperty("STAR_NAME", "Sol")
+    assertThat(generator.getRequestBody(), Matchers.equalTo("{\"query\": \"select * from known_stars\""));
+  }
+
+  @Test
+  public void testGetRequestBody_configUndefined() {
+    generator.configure(Collections.emptyMap());
+    assertThat(generator.getRequestBody(), Matchers.equalTo(""));
+  }
+
+  @Test
+  public void testGetRequestParameters() {
+    generator.configure(CONFIG_PROPS);
+    assertThat(generator.getRequestParameters(), allOf(hasEntry("priority", "MAXIMUM"), hasEntry("paged", "FALSE")));
+  }
+
+  @Test
+  public void testGetRequestParameters_configUndefined() {
+    generator.configure(Collections.emptyMap());
+    assertThat(generator.getRequestParameters(), not(hasKey(anything())));
+  }
+
+  @Test
+  public void testGetRequestHeaders() {
+    generator.configure(CONFIG_PROPS);
+    assertThat(generator.getRequestHeaders(), allOf(
+      hasEntry("Content-Type", "application/json"), hasEntry("Accept", "application/json")));
+  }
+
+  @Test
+  public void testGetRequestHeaders_configUndefined() {
+    generator.configure(Collections.emptyMap());
+    assertThat(generator.getRequestHeaders(), not(hasKey(anything())));
+  }
+
+  @Test
+  public void testGetOffsets() {
+    generator.configure(CONFIG_PROPS);
+    assertThat(generator.getOffsets(), hasEntry(Matchers.equalTo("timestamp"), instanceOf(Long.class)));
+  }
+
+  @Test
+  public void testSetOffsets() {
+    generator.configure(CONFIG_PROPS);
+    generator.setOffsets(null);
+    assertThat(generator.getOffsets(), notNullValue());
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/VelocityTemplateEngineTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/VelocityTemplateEngineTest.java
@@ -1,0 +1,28 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class VelocityTemplateEngineTest {
+
+  ValueProvider valProvider = mock(ValueProvider.class);
+
+  VelocityTemplateEngine engine = new VelocityTemplateEngine();
+
+  @Test
+  public void renderTemplate() {
+    when(valProvider.lookupValue("name")).thenReturn("Noddy");
+    assertThat(engine.renderTemplate("Hello ${name}", valProvider), equalTo("Hello Noddy"));
+  }
+
+  @Test
+  public void renderTemplate_undefinedValue() {
+    assertThat(engine.renderTemplate("Hello ${name}", valProvider), equalTo("Hello ${name}"));
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderConfigTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderConfigTest.java
@@ -1,0 +1,32 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertThat;
+
+
+public class XPathResponseValueProviderConfigTest {
+
+  @Test
+  public void testConfig() {
+    Map<String, Object> props = new HashMap<>();
+
+    props.put("rest.source.response.var.names", "key1, key2");
+    props.put("rest.source.response.var.key1.xpath", "/bookstore/book[1]");
+    props.put("rest.source.response.var.key2.xpath", "//title[@lang]");
+
+    XPathResponseValueProviderConfig config = new XPathResponseValueProviderConfig(props);
+
+    assertThat(config.getResponseVariableNames(), contains("key1", "key2"));
+    assertThat(config.getResponseVariableXPaths(), allOf(
+      hasEntry("key1", "/bookstore/book[1]"),
+      hasEntry("key2", "//title[@lang]")));
+  }
+}

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderTest.java
@@ -3,6 +3,7 @@ package com.tm.kafka.connect.rest.http.payload.templated;
 
 import com.tm.kafka.connect.rest.http.Request;
 import com.tm.kafka.connect.rest.http.Response;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -19,6 +20,11 @@ public class XPathResponseValueProviderTest {
   Response response = mock(Response.class);
 
   XPathResponseValueProvider provider = new XPathResponseValueProvider();
+
+  @Before
+  public void before() {
+    provider.configure(Collections.emptyMap());
+  }
 
   @Test
   public void extractValuesTest_oneMatch() {
@@ -57,7 +63,7 @@ public class XPathResponseValueProviderTest {
     provider.setExpressions(Collections.singletonMap("name", "/greeting/title"));
     when(response.getPayload()).thenReturn("<greeting<hailHello><");
     provider.extractValues(request, response);
-    assertThat(provider.getParameters(), hasEntry("name", null));
+    assertThat(provider.getParameters(), not(hasKey(anything())));
   }
 
   @Test

--- a/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderTest.java
+++ b/kafka-connect-rest-plugin/src/test/java/com/tm/kafka/connect/rest/http/payload/templated/XPathResponseValueProviderTest.java
@@ -1,0 +1,82 @@
+package com.tm.kafka.connect.rest.http.payload.templated;
+
+
+import com.tm.kafka.connect.rest.http.Request;
+import com.tm.kafka.connect.rest.http.Response;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class XPathResponseValueProviderTest {
+
+  Request request = mock(Request.class);
+  Response response = mock(Response.class);
+
+  XPathResponseValueProvider provider = new XPathResponseValueProvider();
+
+  @Test
+  public void extractValuesTest_oneMatch() {
+    provider.setExpressions(Collections.singletonMap("name", "/greeting/name"));
+    when(response.getPayload()).thenReturn("<greeting><hail>Hello</hail><name>Big Ears</name></greeting>");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", "Big Ears"));
+  }
+
+  @Test
+  public void extractValuesTest_multipleMatches() {
+    provider.setExpressions(Collections.singletonMap("name", "/greeting/name"));
+    when(response.getPayload()).thenReturn("<greeting><hail>Hello</hail><name>Big Ears</name><name>Noddy</name></greeting>");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", "Big Ears,Noddy"));
+  }
+
+  @Test
+  public void extractValuesTest_noMatch() {
+    provider.setExpressions(Collections.singletonMap("name", "/greeting/title"));
+    when(response.getPayload()).thenReturn("<greeting><hail>Hello</hail><name>Big Ears</name></greeting>");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", null));
+  }
+
+  @Test
+  public void extractValuesTest_illegalXPath() {
+    provider.setExpressions(Collections.singletonMap("name", "/[/]title"));
+    when(response.getPayload()).thenReturn("<greeting><hail>Hello</hail><name>Big Ears</name></greeting>");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), not(hasKey(anything())));
+  }
+
+  @Test
+  public void extractValuesTest_illegalXML() {
+    provider.setExpressions(Collections.singletonMap("name", "/greeting/title"));
+    when(response.getPayload()).thenReturn("<greeting<hailHello><");
+    provider.extractValues(request, response);
+    assertThat(provider.getParameters(), hasEntry("name", null));
+  }
+
+  @Test
+  public void lookupValueTest_extracted() {
+    provider.setExpressions(Collections.singletonMap("name", "/greeting/name"));
+    when(response.getPayload()).thenReturn("<greeting><hail>Hello</hail><name>Big Ears</name></greeting>");
+    provider.extractValues(request, response);
+    assertThat(provider.lookupValue("name"), equalTo("Big Ears"));
+  }
+
+  @Test
+  public void lookupValueTest_fromEnvironment() {
+    System.setProperty("test", "yeah");
+    assertThat(provider.lookupValue("test"), equalTo("yeah"));
+  }
+
+  @Test
+  public void lookupValueTest_notDefined() {
+    System.clearProperty("test");
+    assertThat(provider.lookupValue("test"), nullValue());
+  }
+}


### PR DESCRIPTION
This PR adds optional templating support into the payload sent with the request.  It allows the request made by the connector to be altered by the response received from the last call.  This is useful in the case of REST services where the client is expected to track state.  A simple example of this is in paged results where the client needs to track the last page received in order to request the next page with the next call.

As mentioned in #17 this is quite a large chunk of functionality which could potentially become its own sub-module if that is a better way to implement it (open to opinions here).